### PR TITLE
Solve conda unresolved command, by splitting installation

### DIFF
--- a/Linux_install/init_tutorial.sh
+++ b/Linux_install/init_tutorial.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+cd ..
 conda init
 . ~/.bashrc
-conda env create --name SOM_env -f lin_tutosub.yml
+conda env create --name SOM_env -f Linux_install/lin_tutosub.yml
 . ~/.bashrc
 source "$(conda info --base)"/etc/profile.d/conda.sh
 conda activate SOM_env
-cd ..
 jupyter notebook

--- a/Linux_install/install_miniconda.sh
+++ b/Linux_install/install_miniconda.sh
@@ -6,10 +6,3 @@ wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O mi
 bash miniconda3/miniconda.sh -b -u -p miniconda3
 rm -rf miniconda3/miniconda.sh
 echo "export PATH=$PWD/miniconda3/bin:$PATH" >> ~/.bashrc
-conda init
-. ~/.bashrc
-conda env create --name SOM_env -f Linux_install/lin_tutosub.yml
-. ~/.bashrc
-source "$(conda info --base)"/etc/profile.d/conda.sh
-conda activate SOM_env
-jupyter notebook

--- a/README.md
+++ b/README.md
@@ -30,14 +30,16 @@ Project is created with:
 * Python 3.6
 	
 ## Setup for Linux
+If you have already miniconda3 skip steps 2) and 3)
 1) Open a terminal in the Linux_install folder
-2) Run if you have already miniconda3 : bash -l init_tutorial.sh
-	   if you don't : bash -l init_tutorial_plus_miniconda.sh
+2) Run if you don't have already miniconda3 : bash -l install_miniconda.sh
+3) Reset your shell for changes, by running in the shell : source ~/.bashrc
+4) Run the script to install packages : bash -l init_tutorial.sh
+	   
 	   
 It will open automatically the jupyter notebook to access tutorials.
 If you close this jupyter session, just run in a NEW shell : jupyter notebook
 to get back.
-
 ## Setup for Windows
 1) Install miniconda3 (skip if you already have) with miniconda3.exe (in folder Windows_install), 
 you should create a miniconda3 folder in workshop folder  and then precise directory folder 


### PR DESCRIPTION
For installing miniconda3 + the package oin Linux:
Still facing "conda unresolved command", because the shell wasn't properly reloaded. We missed this error because the path was previously defined in .bashrc during our test. So now I suggest to have 2 different scripts : one just to install the submapp package and dependencies and an other for people who doesn't have miniconda. The README.md was modified in consequence.